### PR TITLE
style: 비밀번호 찾기, 회원가입 인증 버튼 UI 수정,  소셜로그인 이미지 호버 효과 추가

### DIFF
--- a/src/pages/LogInPage.tsx
+++ b/src/pages/LogInPage.tsx
@@ -16,7 +16,7 @@ interface SocialLoginButtonProps {
 }
 
 const SocialLoginButton: React.FC<SocialLoginButtonProps> = ({ provider, logo, redirectUrl }) => (
-  <a href={redirectUrl} className='mx-6 inline-block'>
+  <a href={redirectUrl} className='mx-6 inline-block transform hover:scale-110'>
     <img src={logo} alt={`${provider} 로그인`} style={{ width: '50px', height: '50px' }} />
   </a>
 );

--- a/src/pages/PasswordResetPage.tsx
+++ b/src/pages/PasswordResetPage.tsx
@@ -61,24 +61,26 @@ const PasswordResetPage: React.FC = () => {
       <form onSubmit={handleSubmit(onSubmit)} className='w-full max-w-lg rounded-lg p-8'>
         {!isEmailSent ? (
           <div>
-            <label htmlFor='email' className='block text-sm font-medium'>
-              이메일
-            </label>
-            <input
-              className='mb-14 mt-2 block h-[50px] w-full rounded-[5px] border border-gray-c4 px-[15px] py-4 text-[16px] shadow-custom-light focus:border-blue-primary focus:outline-none focus:ring-blue-primary'
-              type='email'
-              id='email'
-              disabled={isLoading}
-              placeholder='이메일을 입력하세요.'
-              {...register('email', {
-                required: '이메일을 입력하세요.',
-                pattern: {
-                  value: /^[a-zA-Z0-9.%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
-                  message: '잘못된 이메일 주소입니다.',
-                },
-              })}
-            />
-            {errors.email && <p className='mt-2 text-sm text-red'>{errors.email.message}</p>}
+            <div className='mb-14'>
+              <label htmlFor='email' className='block text-sm font-medium'>
+                이메일
+              </label>
+              <input
+                className='mt-2 block h-[50px] w-full rounded-[5px] border border-gray-c4 px-[15px] py-4 text-[16px] shadow-custom-light focus:border-blue-primary focus:outline-none focus:ring-blue-primary'
+                type='email'
+                id='email'
+                disabled={isLoading}
+                placeholder='이메일을 입력하세요.'
+                {...register('email', {
+                  required: '이메일을 입력하세요.',
+                  pattern: {
+                    value: /^[a-zA-Z0-9.%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+                    message: '잘못된 이메일 주소입니다.',
+                  },
+                })}
+              />
+              {errors.email && <p className='mt-2 text-sm text-red'>{errors.email.message}</p>}
+            </div>
             <button
               className={`flex h-[50px] w-full items-center justify-center rounded-xl font-semibold text-white shadow-custom-light ${
                 isLoading ? 'bg-blue-hover' : 'bg-blue-primary hover:bg-blue-hover'

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -151,7 +151,7 @@ const SignUpPage: React.FC = () => {
             />
             <button
               type='button'
-              className={`ml-2 mt-2 flex h-[50px] items-center justify-center rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isUsernameVerified ? 'bg-gray-c4' : 'bg-blue-primary hover:bg-blue-hover'}`}
+              className={`ml-2 mt-2 flex h-[50px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isUsernameVerified ? 'bg-gray-c4' : 'bg-blue-primary hover:bg-blue-hover'}`}
               onClick={verifyUsername}
               disabled={isUsernameVerified}
             >
@@ -180,11 +180,11 @@ const SignUpPage: React.FC = () => {
             />
             <button
               type='button'
-              className={`ml-2 mt-2 flex h-[50px] items-center justify-center rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isVerificationCodeSent ? 'bg-gray-c4' : 'bg-blue-primary hover:bg-blue-hover'}`}
+              className={`ml-2 mt-2 flex h-[50px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isVerificationCodeSent ? 'bg-gray-c4' : 'bg-blue-primary hover:bg-blue-hover'}`}
               onClick={requestVerificationCode}
               disabled={isVerificationCodeSent}
             >
-              {isVerificationCodeSent ? '코드 발송 완료' : '코드 요청'}
+              {isVerificationCodeSent ? '발송 완료' : '코드 요청'}
             </button>
           </div>
           {errors.email && <p className='mt-2 text-sm text-red'>{errors.email?.message}</p>}
@@ -204,7 +204,7 @@ const SignUpPage: React.FC = () => {
               />
               <button
                 type='button'
-                className={`ml-2 mt-2 flex h-[50px] items-center justify-center rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isEmailVerified ? 'bg-gray-c4' : 'bg-blue-primary hover:bg-blue-hover'}`}
+                className={`ml-2 mt-2 flex h-[50px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isEmailVerified ? 'bg-gray-c4' : 'bg-blue-primary hover:bg-blue-hover'}`}
                 onClick={verifyCode}
                 disabled={isEmailVerified}
               >


### PR DESCRIPTION
## 📝 제목: [유형] 간결한 변경 내용 요약

**유형 (Type):**

- Style

**간결한 변경 내용 요약:**

## 📑 비밀번호 찾기, 회원가입 인증 버튼 UI 수정, 소셜로그인 이미지 호버 효과 추가

**변경 사항에 대한 자세한 설명:**

- 회원가입: 닉네임 인증/이메일 인증 글을 수정하고 한 줄에 있도록 했습니다.
<img width="517" alt="스크린샷 2024-08-28 오후 4 45 50" src="https://github.com/user-attachments/assets/7defc5ef-f4de-42ca-88c4-5359f1d56388">

- 비밀번호찾기: 유효성검사 문구위치가 버튼위쪽에 붙어있어, input창 밑으로 옮겼습니다.
<img width="472" alt="스크린샷 2024-08-28 오후 4 46 13" src="https://github.com/user-attachments/assets/014ee0de-a185-4a01-a704-f201491683bc">

- 로그인: 소셜로그인 이미지 호버하면 이미지가 10% 확대되는 효과를 추가하였습니다.

**관련 이슈 (Optional):**

- [관련된 이슈가 있다면 링크를 첨부합니다. 예: #123]

## 🙋 리뷰어에게 전달할 말 (Optional)

- [리뷰 시 특별히 확인해야 할 부분이 있다면 알려주세요.]
- [추가적인 질문이나 의견이 있다면 자유롭게 작성해주세요.]
