### PR TITLE
Fix: 배포된 백엔드 api 반영, 에러 해결

### DIFF
--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -10,9 +10,9 @@ import categories from '../../data/categories.json';
 const Navbar: React.FC = () => {
   const navigate = useNavigate();
 
-  const { isLoggedIn, nickname, logOut } = useAuthStore((state) => ({
+  const { isLoggedIn, username, logOut } = useAuthStore((state) => ({
     isLoggedIn: state.isLoggedIn,
-    nickname: state.nickname,
+    username: state.username,
     logOut: state.logOut,
   }));
 
@@ -79,7 +79,7 @@ const Navbar: React.FC = () => {
                   onClick={() => navigate('/mypage')}
                   className='mr-1 cursor-pointer whitespace-nowrap text-[12px] hover:font-bold hover:text-blue-hover hover:underline sm:text-[16px]'
                 >
-                  {nickname}
+                  {username}
                 </p>
                 <NavBtn onClick={handleLogout} className='bg-white text-black hover:bg-white-f9'>
                   로그아웃

--- a/src/pages/DeleteAccout.tsx
+++ b/src/pages/DeleteAccout.tsx
@@ -16,7 +16,7 @@ const DeleteAccountPage: React.FC = () => {
   } = useForm<FormValues>();
   const [isDeleting, setIsDeleting] = React.useState(false);
 
-  // const baseUrl = import.meta.env.VITE_API_URL;
+  const baseUrl = import.meta.env.VITE_API_URL;
 
   const onSubmit = async (data: FormValues) => {
     if (data.confirmation === '위의 내용에 동의하며, 탈퇴하겠습니다.') {
@@ -24,8 +24,7 @@ const DeleteAccountPage: React.FC = () => {
         setIsDeleting(true);
 
         try {
-          await axios.delete('http://223.130.128.216:8000/accounts/account-delete/');
-          // await axios.delete(`${baseUrl}/api/v1/accounts/account-delete`);
+          await axios.delete(`${baseUrl}/accounts/account-delete/`);
           alert('탈퇴가 완료되었습니다.');
           // 토큰 삭제 후 홈으로 리다이렉트
           useAuthStore.getState().logOut();

--- a/src/pages/LogInPage.tsx
+++ b/src/pages/LogInPage.tsx
@@ -16,6 +16,8 @@ interface SocialLoginButtonProps {
   redirectUrl: string;
 }
 
+const baseUrl = import.meta.env.VITE_API_URL;
+
 const SocialLoginButton: React.FC<SocialLoginButtonProps> = ({ provider, logo, redirectUrl }) => (
   <a href={redirectUrl} className='mx-6 inline-block transform hover:scale-110'>
     <img src={logo} alt={`${provider} 로그인`} style={{ width: '50px', height: '50px' }} />
@@ -35,11 +37,11 @@ const LogInPage: React.FC = () => {
   const { logIn } = useAuthStore((state) => ({ logIn: state.logIn }));
 
   const loginUser = (data: LogInInputs) => {
-    return axios.post('http://223.130.128.216:8000/accounts/login/', data, { withCredentials: true });
+    return axios.post(`${baseUrl}/accounts/login/`, data, { withCredentials: true });
   };
 
-  const handleLoginSuccess = (userId: number, nickname: string, email: string) => {
-    logIn(userId, nickname, email);
+  const handleLoginSuccess = (userId: number, username: string, email: string) => {
+    logIn(userId, username, email);
     console.log('Login successful!');
     navigate('/');
   };
@@ -49,8 +51,8 @@ const LogInPage: React.FC = () => {
     try {
       const response = await loginUser(data);
       console.log('로그인 성공:', response.data);
-      const { userId, nickname, email } = response.data;
-      handleLoginSuccess(userId, nickname, email);
+      const { userId, username, email } = response.data;
+      handleLoginSuccess(userId, username, email);
     } catch (error: any) {
       if (error.response?.data?.message) {
         const errorMessage = error.response.data.message;
@@ -80,9 +82,10 @@ const LogInPage: React.FC = () => {
   };
 
   // 소셜 로그인 버튼의 리다이렉트 URL 설정
-  const googleLoginUrl = 'http://223.130.128.216:8000/accounts/google/login';
-  const kakaoLoginUrl = 'http://223.130.128.216:8000/accounts/kakao/login/';
-  const naverLoginUrl = 'http://223.130.128.216:8000/accounts/naver/login/';
+  const googleLoginUrl = `${baseUrl}/accounts/google/login/`;
+  // const kakaoLoginUrl = 'http://127.0.0.1:8000/accounts/kakao/login';
+  const kakaoLoginUrl = `${baseUrl}/accounts/kakao/login/`;
+  const naverLoginUrl = `${baseUrl}/accounts/naver/login/`;
 
   return (
     <div className='flex min-h-screen flex-col items-center justify-center'>

--- a/src/pages/PasswordResetPage.tsx
+++ b/src/pages/PasswordResetPage.tsx
@@ -21,30 +21,25 @@ const PasswordResetPage: React.FC = () => {
     formState: { errors },
   } = useForm<PasswordResetInputs>();
 
-  // const baseUrl = import.meta.env.VITE_API_URL;
+  const baseUrl = import.meta.env.VITE_API_URL;
   const navigate = useNavigate();
   const location = useLocation();
 
-  // URL에서 token 쿼리 파라미터를 추출합니다.
+  // URL에서 token 쿼리 파라미터를 추출
   const queryParams = new URLSearchParams(location.search);
   const token = queryParams.get('token');
 
   console.log('Token from URL:', token); // Token 확인용
 
   const sendPasswordResetEmail = async (email: string) => {
-    return axios.post('http://223.130.128.216:8000/accounts/password-reset/', { email });
-    // return axios.post(`${baseUrl}/api/v1/accounts/password-reset`, { email });
+    return axios.post(`${baseUrl}/accounts/password-reset/`, { email });
   };
 
   const resetPassword = async (data: PasswordResetInputs) => {
-    return axios.post('http://223.130.128.216:8000/accounts/password-reset/confirm', {
+    return axios.post(`${baseUrl}/accounts/password-reset/confirm/`, {
       ...data,
       token, // token을 추가하여 서버에 전송
     });
-    // return axios.post(`${baseUrl}/api/v1/accounts/password-reset/confirm`, {
-    //   ...data,
-    //   token, // token을 추가하여 서버에 전송
-    // });
   };
 
   const onSubmit: SubmitHandler<PasswordResetInputs> = async (data) => {

--- a/src/pages/RedirectHandlerPage.tsx
+++ b/src/pages/RedirectHandlerPage.tsx
@@ -10,12 +10,12 @@ const RedirectHandlerPage: React.FC = () => {
     // URL에서 쿼리 파라미터 추출
     const params = new URLSearchParams(window.location.search);
     const userId = parseInt(params.get('userId') || '', 10);
-    const nickname = params.get('nickname') || '';
+    const username = params.get('username') || '';
     const email = params.get('email') || '';
 
-    if (userId && nickname && email) {
+    if (userId && username && email) {
       // Zustand 스토어에 사용자 데이터 저장
-      logIn(userId, nickname, email);
+      logIn(userId, username, email);
       // 로그인 성공 후 홈으로 리다이렉트
       navigate('/');
     } else {

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -11,7 +11,7 @@ interface SignUpFormInputs {
   verificationCode: string;
 }
 
-// const baseUrl = import.meta.env.VITE_API_URL;
+const baseUrl = import.meta.env.VITE_API_URL;
 
 const SignUpPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -39,13 +39,13 @@ const SignUpPage: React.FC = () => {
     }
 
     try {
-      const response = await axios.post('http://127.0.0.1:8000/accounts/check-username/', { username });
-      // const response = await axios.post(`${baseUrl}/api/v1/accounts/check-username`, { username });
+      const response = await axios.post(`${baseUrl}/accounts/check-username/`, { username });
       if (response.data.message === '사용 가능한 닉네임입니다.') {
         setIsUsernameVerified(true);
         alert('닉네임 인증이 완료되었습니다.');
       } else {
         setIsUsernameVerified(false);
+        console.log(response.data.message);
         alert('이미 사용 중인 닉네임입니다.');
       }
     } catch (error) {
@@ -62,9 +62,19 @@ const SignUpPage: React.FC = () => {
       return;
     }
 
+    // try {
+    //   // 1. 이메일 중복 여부 확인
+    //   const emailCheckResponse = await axios.post(`${baseUrl}/accounts/check-email/`, { email });
+
+    //   if (emailCheckResponse.data.message === '이미 존재하는 이메일입니다.') {
+    //     // 2. 이메일이 이미 존재할 경우 오류 메시지 표시
+    //     setError('email', { type: 'manual', message: '이미 존재하는 이메일입니다. 다른 이메일을 입력하세요.' });
+    //     return;
+    //   }
+
+    // 3. 이메일이 중복되지 않을 경우 인증 코드 요청
     try {
-      const response = await axios.post('http://127.0.0.1:8000/accounts/send-verification-code/', { email });
-      // const response = await axios.post(`${baseUrl}/api/v1/accounts/send-verification-code`, { email });
+      const response = await axios.post(`${baseUrl}/accounts/send-verification-code/`, { email });
       if (response.data.detail === '인증 코드가 이메일로 전송되었습니다.') {
         setIsVerificationCodeSent(true);
         alert('인증 코드가 이메일로 전송되었습니다.');
@@ -87,8 +97,7 @@ const SignUpPage: React.FC = () => {
     }
 
     try {
-      const response = await axios.post('http://127.0.0.1:8000/accounts/verify-code/', {
-        // const response = await axios.post(`${baseUrl}/api/v1/accounts/verify-code`, {
+      const response = await axios.post(`${baseUrl}/accounts/verify-code/`, {
         email,
         verification_code: verificationCode,
       });
@@ -117,11 +126,12 @@ const SignUpPage: React.FC = () => {
     }
 
     setIsLoading(true);
+
     try {
-      const response = await axios.post('http://127.0.0.1:8000/accounts/register/', {
-        // const response = await axios.post(`${baseUrl}/api/v1/accounts/register-final`, {
+      const response = await axios.post(`${baseUrl}/accounts/register/`, {
         email: data.email,
         username: data.username,
+        verification_code: data.verificationCode,
         password: data.password,
       });
       console.log(response.data);
@@ -154,7 +164,7 @@ const SignUpPage: React.FC = () => {
             />
             <button
               type='button'
-              className={`ml-2 mt-2 flex h-[50px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isUsernameVerified ? 'bg-gray-c4' : 'bg-blue-primary hover:bg-blue-hover'}`}
+              className={`ml-2 mt-2 flex h-[50px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isUsernameVerified ? 'bg-gray-db' : 'bg-blue-primary hover:bg-blue-hover'}`}
               onClick={verifyUsername}
               disabled={isUsernameVerified}
             >
@@ -183,7 +193,7 @@ const SignUpPage: React.FC = () => {
             />
             <button
               type='button'
-              className={`ml-2 mt-2 flex h-[50px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isVerificationCodeSent ? 'bg-gray-c4' : 'bg-blue-primary hover:bg-blue-hover'}`}
+              className={`ml-2 mt-2 flex h-[50px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isVerificationCodeSent ? 'bg-gray-db' : 'bg-blue-primary hover:bg-blue-hover'}`}
               onClick={requestVerificationCode}
               disabled={isVerificationCodeSent}
             >
@@ -207,7 +217,7 @@ const SignUpPage: React.FC = () => {
               />
               <button
                 type='button'
-                className={`ml-2 mt-2 flex h-[50px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isEmailVerified ? 'bg-gray-c4' : 'bg-blue-primary hover:bg-blue-hover'}`}
+                className={`ml-2 mt-2 flex h-[50px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 font-semibold text-white shadow-custom-light ${isEmailVerified ? 'bg-gray-db' : 'bg-blue-primary hover:bg-blue-hover'}`}
                 onClick={verifyCode}
                 disabled={isEmailVerified}
               >

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -12,9 +12,9 @@ export const useAnalysisRequestSite = create<AnalysisRequestSiteState>((set) => 
 interface AuthState {
   isLoggedIn: boolean; // 로그인 상태
   userId: number | null; // 사용자 ID
-  nickname: string | null; // 닉네임
+  username: string | null; // 닉네임
   email: string | null; // 이메일
-  logIn: (userId: number, nickname: string, email: string) => void; // 로그인 함수
+  logIn: (userId: number, username: string, email: string) => void; // 로그인 함수
   logOut: () => void; // 로그아웃 함수
 }
 
@@ -24,15 +24,15 @@ export const useAuthStore = create(
     (set) => ({
       isLoggedIn: false, // 기본 로그인 상태는 false로 설정
       userId: null, // 초기 사용자 ID 값 null
-      nickname: null, // 초기 닉네임 값 null
+      username: null, // 초기 닉네임 값 null
       email: null, // 초기 이메일 값 null
 
       // 로그인 성공 시 실행될 함수
-      logIn: (userId, nickname, email) =>
+      logIn: (userId, username, email) =>
         set(() => ({
           isLoggedIn: true,
           userId,
-          nickname,
+          username,
           email,
         })),
 
@@ -41,7 +41,7 @@ export const useAuthStore = create(
         set(() => ({
           isLoggedIn: false,
           userId: null,
-          nickname: null,
+          username: null,
           email: null,
         })),
     }),


### PR DESCRIPTION
## 📝 제목: Fix: 배포된 백엔드 api 반영, 에러 해결

**유형 (Type):**

- Feat, Fix, Style

**간결한 변경 내용 요약:**

[배포된 백엔드 api 반영, 에러 해결]

## 📑 상세 설명

**변경 사항에 대한 자세한 설명:**

- Fix: 백엔드에서 에러가 나는 nickname을 삭제함에 따라 nickname을 username으로 변경<br />
- Fix: 회원가입 요청시 인자에 이메일 인증 확인 코드 추가
- Style: 회원 가입 인증 버튼 색상 변경
-  Feat: 회원가입 시 중복된 이메일로 회원가입을 시도할 경우, 회원가입 버튼을 눌렀을 때 에러가 납니다. 이를 해결하기 위해 회원가입 시 이메일 중복 인증 로직을 추가했습니다. 
<hr />
<img width="345" alt="스크린샷 2024-08-30 오후 5 01 46" src="https://github.com/user-attachments/assets/85ec8b15-1616-4bc3-b586-767931a8f543"><br />
<br />

**관련 이슈 (Optional):**

- [관련된 이슈가 있다면 링크를 첨부합니다. 예: #123]

## 🙋 리뷰어에게 전달할 말 (Optional)

- 이메일 로그인 시 유저 Id가 로컬 스토리지에 담기지 않는데, 그 이유는 응답데이터의 유저 Id 키가 userId가 아닌 id이기 때문입니다.
이 부분은 소셜로그인의 키(userId)와 통일하기로 하였고 시안님께서 내일 수정해주신다고 하셨습니다.<br />
- 이메일 중복 인증 api도 시안님께서 내일 추가해주시기로 했습니다. 그래서 추가한 이메일 중복 인증 로직은 일단 주석 처리했습니다.