### PR TITLE
Fix: /accounts/password-reset/confirm로 요청을 보낼 때, 토큰 전달 방식 수정

### DIFF
--- a/src/pages/PasswordResetPage.tsx
+++ b/src/pages/PasswordResetPage.tsx
@@ -44,9 +44,8 @@ const PasswordResetPage: React.FC = () => {
     return axios.post(`${baseUrl}/accounts/password-reset/`, { email });
   };
   const resetPassword = async (data: PasswordResetInputs) => {
-    return axios.post(`${baseUrl}/accounts/password-reset/confirm/`, {
+    return axios.post(`${baseUrl}/accounts/password-reset/confirm/?token=${token}`, {
       password: data.password,
-      token, // token을 추가하여 서버에 전송
     });
   };
   const onSubmit: SubmitHandler<PasswordResetInputs> = async (data) => {


### PR DESCRIPTION
## 📝 제목: [유형] 간결한 변경 내용 요약

**유형 (Type):**

- Fix: 버그 수정

**간결한 변경 내용 요약:**

[/accounts/password-reset/confirm로 요청을 보낼 때, 토큰 전달 방식 수정]

## 📑 상세 설명

**변경 사항에 대한 자세한 설명:**

-  백엔드 코드를 보니 비밀번호 재설정 api로 post 요청을 보낼 때, 토큰을 요청 바디가 아닌 쿼리 파라미터로 받도록 되어 있어, 이에 맞게 수정했습니다.
<img width="448" alt="스크린샷 2024-09-07 오후 4 23 45" src="https://github.com/user-attachments/assets/2e7f1cba-f9ba-4bcd-a9aa-fb3618a56c67"> <br />
하지만 새 비밀번호가 password와 new_password로 통일이 되지 않은 채 사용되고 있어 오류가 발생하게 될 것으로 보입니다. 
<img width="467" alt="스크린샷 2024-09-07 오후 4 46 30" src="https://github.com/user-attachments/assets/5f3f5677-76a3-4404-bf8f-4d38e6977f28">
<img width="415" alt="스크린샷 2024-09-07 오후 4 46 59" src="https://github.com/user-attachments/assets/b3c5f68b-ff1b-4139-8721-d4c9f26ce488">


**관련 이슈 (Optional):**

- [관련된 이슈가 있다면 링크를 첨부합니다. 예: #123]

## 🙋 리뷰어에게 전달할 말 (Optional)

- [리뷰 시 특별히 확인해야 할 부분이 있다면 알려주세요.]
- [추가적인 질문이나 의견이 있다면 자유롭게 작성해주세요.]
